### PR TITLE
lookup SLACK_WEBHOOK_URL from AWS secrets manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ You can find more examples in the [`examples/`](./examples/) directory
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.16.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_slack_notifications"></a> [slack\_notifications](#module\_slack\_notifications) | terraform-aws-modules/lambda/aws | 3.2.0 |
+| <a name="module_slack_notifications"></a> [slack\_notifications](#module\_slack\_notifications) | terraform-aws-modules/lambda/aws | 5.0.0 |
 
 ## Resources
 
@@ -49,6 +49,8 @@ You can find more examples in the [`examples/`](./examples/) directory
 |------|------|
 | [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -62,10 +64,12 @@ You can find more examples in the [`examples/`](./examples/) directory
 | <a name="input_enable_ecs_deployment_state_event_rule"></a> [enable\_ecs\_deployment\_state\_event\_rule](#input\_enable\_ecs\_deployment\_state\_event\_rule) | The boolean flag enabling the EvenBridge Rule for `ECS Deployment State Change` events. The `detail` section of this rule is configured with `ecs_deployment_state_event_rule_detail` variable. | `bool` | `true` | no |
 | <a name="input_enable_ecs_service_action_event_rule"></a> [enable\_ecs\_service\_action\_event\_rule](#input\_enable\_ecs\_service\_action\_event\_rule) | The boolean flag enabling the EvenBridge Rule for `ECS Service Action` events. The `detail` section of this rule is configured with `ecs_service_action_event_rule_detail` variable. | `bool` | `true` | no |
 | <a name="input_enable_ecs_task_state_event_rule"></a> [enable\_ecs\_task\_state\_event\_rule](#input\_enable\_ecs\_task\_state\_event\_rule) | The boolean flag enabling the EvenBridge Rule for `ECS Task State Change` events. The `detail` section of this rule is configured with `ecs_task_state_event_rule_detail` variable. | `bool` | `true` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Amount of memory in MB your Lambda Function can use at runtime. Valid value between 128 MB to 10,240 MB (10 GB), in 64 MB increments. | `number` | `256` | no |
 | <a name="input_name"></a> [name](#input\_name) | The string which will be used for the name of AWS Lambda function and other creaated resources | `string` | n/a | yes |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not. | `bool` | `true` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The string which will be used for the name of Lambda IAM role | `string` | `null` | no |
-| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | Slack incoming webhook URL | `string` | n/a | yes |
+| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | Slack incoming webhook URL. If slack\_webhook\_url\_secretsmanager\_lookup is true then this must match your secretsmanager secret name. | `string` | n/a | yes |
+| <a name="input_slack_webhook_url_secretsmanager_lookup"></a> [slack\_webhook\_url\_secretsmanager\_lookup](#input\_slack\_webhook\_url\_secretsmanager\_lookup) | Lookup the slack incoming webhook URL stored in AWS secrets manager. slack\_webhook\_url must match your secretsmanager secret name. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/simple-secretsmanager/main.tf
+++ b/examples/simple-secretsmanager/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "ecs_to_slack" {
+  source            = "../../"
+  name              = "ecs-to-slack"
+  
+  # Use the secretsmanager secret name instead or the plaintext hook url. This must exist prior to apply!
+  slack_webhook_url = "/org/dev/slack_webhook_url"
+  # Required to allow secretsmanager lookups.
+  slack_webhook_url_secretsmanager_lookup = true
+
+  # We do not override any built-in event rules, so the default values will be used
+}

--- a/functions/slack_notifications.py
+++ b/functions/slack_notifications.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import http.client
+import boto3
 
 # ---------------------------------------------------------------------------------------------------------------------
 # ENVIRONMENTAL VARIABLES
@@ -9,6 +10,8 @@ import http.client
 
 # Boolean flag, which determins if the incoming even should be printed to the output.
 LOG_EVENTS = os.getenv('LOG_EVENTS', 'False').lower() in ('true', '1', 't', 'yes', 'y')
+
+SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP = os.getenv('SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP', 'False').lower() in ('true', '1', 't', 'yes', 'y')
 
 SLACK_WEBHOOK_URL = os.getenv('SLACK_WEBHOOK_URL', '')
 if SLACK_WEBHOOK_URL == '':
@@ -18,6 +21,15 @@ if SLACK_WEBHOOK_URL == '':
 logging.basicConfig()
 log = logging.getLogger()
 log.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+if SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP:
+    secretsmanager = boto3.client('secretsmanager')
+
+    secretsmanagerResponse = secretsmanager.get_secret_value(
+        SecretId = SLACK_WEBHOOK_URL,
+    )
+    
+    SLACK_WEBHOOK_URL = secretsmanagerResponse['SecretString']
 
 # ---------------------------------------------------------------------------------------------------------------------
 # HELPER FUNCTIONS

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "slack_webhook_url" {
-  description = "Slack incoming webhook URL"
+  description = "Slack incoming webhook URL. If slack_webhook_url_secretsmanager_lookup is true then this must match your secretsmanager secret name."
   type        = string
 }
 
@@ -22,6 +22,12 @@ variable "role_name" {
   description = "The string which will be used for the name of Lambda IAM role"
   type        = string
   default     = null
+}
+
+variable "slack_webhook_url_secretsmanager_lookup" {
+  description = "Lookup the slack incoming webhook URL stored in AWS secrets manager. slack_webhook_url must match your secretsmanager secret name."
+  type        = bool
+  default     = false
 }
 
 variable "enable_ecs_task_state_event_rule" {


### PR DESCRIPTION
rather than passing in the slack webhook url as plaintext variable to the module you can allow lookup of the SLACK_WEBHOOK_URL from aws secretsmanager from the lambda