### PR TITLE
use new source_type variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can find more examples in the [`examples/`](./examples/) directory
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.16.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
 
 ## Modules
 
@@ -68,8 +68,8 @@ You can find more examples in the [`examples/`](./examples/) directory
 | <a name="input_name"></a> [name](#input\_name) | The string which will be used for the name of AWS Lambda function and other creaated resources | `string` | n/a | yes |
 | <a name="input_recreate_missing_package"></a> [recreate\_missing\_package](#input\_recreate\_missing\_package) | Whether to recreate missing Lambda package if it is missing locally or not. | `bool` | `true` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The string which will be used for the name of Lambda IAM role | `string` | `null` | no |
-| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | Slack incoming webhook URL. If slack\_webhook\_url\_secretsmanager\_lookup is true then this must match your secretsmanager secret name. | `string` | n/a | yes |
-| <a name="input_slack_webhook_url_secretsmanager_lookup"></a> [slack\_webhook\_url\_secretsmanager\_lookup](#input\_slack\_webhook\_url\_secretsmanager\_lookup) | Lookup the slack incoming webhook URL stored in AWS secrets manager. slack\_webhook\_url must match your secretsmanager secret name. | `bool` | `false` | no |
+| <a name="input_slack_webhook_url_source"></a> [slack\_webhook\_url\_source](#input\_slack\_webhook\_url\_source) | (default) Slack incoming webhook URL. (if slack\_webhook\_url\_source\_type is 'secret') A secretsmanager secret name. | `string` | n/a | yes |
+| <a name="input_slack_webhook_url_source_type"></a> [slack\_webhook\_url\_source\_type](#input\_slack\_webhook\_url\_source\_type) | Define where to get the slack webhook URL for variable slack\_webhook\_url\_source. Either as text input or from an AWS secretsmanager lookup | `string` | `"text"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/functions/slack_notifications.py
+++ b/functions/slack_notifications.py
@@ -11,7 +11,7 @@ import boto3
 # Boolean flag, which determins if the incoming even should be printed to the output.
 LOG_EVENTS = os.getenv('LOG_EVENTS', 'False').lower() in ('true', '1', 't', 'yes', 'y')
 
-SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP = os.getenv('SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP', 'False').lower() in ('true', '1', 't', 'yes', 'y')
+SLACK_WEBHOOK_URL_SOURCE_TYPE = os.getenv('SLACK_WEBHOOK_URL_SOURCE_TYPE', 'text').lower()
 
 SLACK_WEBHOOK_URL = os.getenv('SLACK_WEBHOOK_URL', '')
 if SLACK_WEBHOOK_URL == '':
@@ -22,7 +22,7 @@ logging.basicConfig()
 log = logging.getLogger()
 log.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
-if SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP:
+if SLACK_WEBHOOK_URL_SOURCE_TYPE == 'secretsmanager':
     secretsmanager = boto3.client('secretsmanager')
 
     secretsmanagerResponse = secretsmanager.get_secret_value(

--- a/main.tf
+++ b/main.tf
@@ -74,16 +74,16 @@ module "slack_notifications" {
   }
 
   environment_variables = {
-    SLACK_WEBHOOK_URL                       = var.slack_webhook_url
-    LOG_EVENTS                              = true
-    LOG_LEVEL                               = "INFO"
-    SLACK_WEBHOOK_URL_SECRETSMANAGER_LOOKUP = var.slack_webhook_url_secretsmanager_lookup
+    SLACK_WEBHOOK_URL             = var.slack_webhook_url_source
+    LOG_EVENTS                    = true
+    LOG_LEVEL                     = "INFO"
+    SLACK_WEBHOOK_URL_SOURCE_TYPE = var.slack_webhook_url_source_type
   }
 
   cloudwatch_logs_retention_in_days = var.cloudwatch_logs_retention_in_days
 
-  attach_policy_json = var.slack_webhook_url_secretsmanager_lookup
-  policy_json = var.slack_webhook_url_secretsmanager_lookup ? jsonencode(
+  attach_policy_json = (var.slack_webhook_url_source_type != "text")
+  policy_json = var.slack_webhook_url_source_type == "secretsmanager" ? jsonencode(
     {
       "Version" : "2012-10-17",
       "Statement" : [
@@ -93,7 +93,7 @@ module "slack_notifications" {
             "secretsmanager:GetSecretValue",
           ],
           "Resource" : [
-            "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.slack_webhook_url}*",
+            "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.slack_webhook_url_source}*",
           ]
         }
       ]

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,8 @@ variable "name" {
   type        = string
 }
 
-variable "slack_webhook_url" {
-  description = "Slack incoming webhook URL. If slack_webhook_url_secretsmanager_lookup is true then this must match your secretsmanager secret name."
+variable "slack_webhook_url_source" {
+  description = "(default) Slack incoming webhook URL. (if slack_webhook_url_source_type is 'secret') A secretsmanager secret name."
   type        = string
 }
 
@@ -24,10 +24,14 @@ variable "role_name" {
   default     = null
 }
 
-variable "slack_webhook_url_secretsmanager_lookup" {
-  description = "Lookup the slack incoming webhook URL stored in AWS secrets manager. slack_webhook_url must match your secretsmanager secret name."
-  type        = bool
-  default     = false
+variable "slack_webhook_url_source_type" {
+  description = "Define where to get the slack webhook URL for variable slack_webhook_url_source. Either as text input or from an AWS secretsmanager lookup"
+  validation {
+    condition     = contains(["text", "secretsmanager"], var.slack_webhook_url_source_type)
+    error_message = "Invalid source type. Must be one of 'text', 'secretsmanager'"
+  }
+  type    = string
+  default = "text"
 }
 
 variable "enable_ecs_task_state_event_rule" {


### PR DESCRIPTION
allows defining multiple ways to have the slack url. as text or from secretsmanager